### PR TITLE
routing.build: Allow multiple values for the same field

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1641,7 +1641,7 @@ class MapAdapter(object):
                 valueiter = iteritems(values, multi=True)
             else:
                 valueiter = iteritems(values)
-            values = dict((k, v) for k, v in valueiter if v is not None)
+            values = MultiDict((k, v) for k, v in valueiter if v is not None)
         else:
             values = {}
 


### PR DESCRIPTION
This allows to construct urls like
'http://example.com/?multi=1&multi=2&multi=3' which have multiple
values for the same field. This is common practice for most web
frameworks. The reverse operation is allready supported, i.e. multiple
values get aggregated into a MultiDict.
